### PR TITLE
verify mpkg sig, add installerRecipe, clean tabs

### DIFF
--- a/Logitech/LogitechCC.download.recipe
+++ b/Logitech/LogitechCC.download.recipe
@@ -2,19 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Description</key>
-	<string>Downloads the latest verison of Logitech Control Center</string>
-	<key>Identifier</key>
-	<string>com.github.joshua-d-miller.download.logitechcc</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>LogiCntr</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.2.9</string>
-	<key>Process</key>
-	<array>
+    <key>Description</key>
+    <string>Downloads the latest verison of Logitech Control Center</string>
+    <key>Identifier</key>
+    <string>com.github.joshua-d-miller.download.logitechcc</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>LogiCntr</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.3.1</string>
+    <key>Process</key>
+    <array>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
@@ -27,15 +27,15 @@
             </dict>
         </dict>
         <dict>
-        	<key>Processor</key>
-        	<string>URLDownloader</string>
-        	<key>Arguments</key>
-        	<dict>
-        		<key>url</key>
-        		<string>%url%</string>
-        		<key>filename</key>
-        		<string>%NAME%.zip</string>
-        	</dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%url%</string>
+                <key>filename</key>
+                <string>%NAME%.zip</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>
@@ -70,10 +70,25 @@
                 </array>
             </dict>
         </dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-	</array>
+    <dict>
+        <key>Processor</key>
+        <string>EndOfCheckPhase</string>
+    </dict>
+    <dict>
+        <key>Processor</key>
+        <string>CodeSignatureVerifier</string>
+        <key>Arguments</key>
+        <dict>
+            <key>input_path</key>
+            <string>%RECIPE_CACHE_DIR%/Logitech Control Center.mpkg</string>
+            <key>expected_authority_names</key>
+            <array>
+                <string>Developer ID Installer: Logitech Inc.</string>
+                <string>Developer ID Certification Authority</string>
+                <string>Apple Root CA</string>
+            </array>
+        </dict>
+    </dict>
+  </array>
 </dict>
 </plist>

--- a/Logitech/LogitechCC.install.recipe
+++ b/Logitech/LogitechCC.install.recipe
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Installs the current release version of MSLync.</string>
+    <key>Identifier</key>
+    <string>com.github.joshua-d-miller.install.logitechcc</string>
+    <key>Input</key>
+    <dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.joshua-d-miller.download.logitechcc</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>Installer</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/Logitech Control Center.mpkg</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Logitech/LogitechCC.install.recipe
+++ b/Logitech/LogitechCC.install.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Installs the current release version of MSLync.</string>
+    <string>Installs the current release version of Logitech Control Center.</string>
     <key>Identifier</key>
     <string>com.github.joshua-d-miller.install.logitechcc</string>
     <key>Input</key>


### PR DESCRIPTION
Added installer recipe, bumped min version number in download to accommodate codeSigVerification reqs, while I was in there cleaned up whitespace(some spaces were tab chars, made everything an even 4)