### PR TITLE
Change to SSL download URL.

### DIFF
--- a/Google Picasa/Picasa.download.recipe
+++ b/Google Picasa/Picasa.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://picasa.google.com</string>
+                <string>https://picasa.google.com</string>
                 <key>re_pattern</key>
                 <string>(?P&lt;url&gt;//dl\.google\.com/dl/picasa/picasamac.*?\.dmg)</string>
             </dict>


### PR DESCRIPTION
Current recipe returns an error that no match was found; I suspect this is because they have moved the page and resource to SSL, so the URL only matches if the base is https instead of http. I'm new at this so I could be completely wrong though. :)