### PR TITLE
New URL for Prezi Desktop binary

### DIFF
--- a/Prezi/Prezi.download.recipe
+++ b/Prezi/Prezi.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>http://prezi.com/mac/</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https://prezi-a.akamaihd.net/desktop/Prezi.*?\.dmg)</string>
+                <string>(?P&lt;url&gt;https://prezi-a.akamaihd.net/next-desktop/mac/Prezi.*?\.dmg)</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Our Prezi.munki autopkg job started failing on friday. It seems that the website has started using a different URL. I updated the URL in the download recipe and now it looks like it's working well.