### PR TITLE
Prezi: New absolute URL - Removed URLTextSearcher

### DIFF
--- a/Prezi/Prezi.download.recipe
+++ b/Prezi/Prezi.download.recipe
@@ -2,34 +2,34 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Description</key>
-	<string>Downloads the latest verison of Prezi</string>
-	<key>Identifier</key>
-	<string>com.github.joshua-d-miller.download.prezi</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>Prezi</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.2.9</string>
-	<key>Process</key>
-	<array>
+    <key>Description</key>
+    <string>Downloads the latest verison of Prezi</string>
+    <key>Identifier</key>
+    <string>com.github.joshua-d-miller.download.prezi</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Prezi</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.9</string>
+    <key>Process</key>
+    <array>
         <dict>
-        	<key>Processor</key>
-        	<string>URLDownloader</string>
-        	<key>Arguments</key>
-        	<dict>
-        		<key>url</key>
-        		<string>https://prezi.com/download/mac/</string>
-        		<key>filename</key>
-        		<string>%NAME%.dmg</string>
-        	</dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://prezi.com/download/mac/</string>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+            </dict>
         </dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-	</array>
+            <dict>
+                <key>Processor</key>
+                <string>EndOfCheckPhase</string>
+            </dict>
+    </array>
 </dict>
 </plist>

--- a/Prezi/Prezi.download.recipe
+++ b/Prezi/Prezi.download.recipe
@@ -16,23 +16,12 @@
 	<key>Process</key>
 	<array>
         <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>http://prezi.com/mac/</string>
-                <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https://prezi-a.akamaihd.net/next-desktop/mac/Prezi.*?\.dmg)</string>
-            </dict>
-        </dict>
-        <dict>
         	<key>Processor</key>
         	<string>URLDownloader</string>
         	<key>Arguments</key>
         	<dict>
         		<key>url</key>
-        		<string>%url%</string>
+        		<string>https://prezi.com/download/mac/</string>
         		<key>filename</key>
         		<string>%NAME%.dmg</string>
         	</dict>


### PR DESCRIPTION
Seems as if they've changed their [website](https://prezi.com/desktop/) again, our jobs started failing this morning.

It looks like they've added an absolute URL for downloading the OS X-version. I've therefore removed the `URLTextSearcher`-processor which had problems and replaced the URL in the `URLDownloader`-processor to download from the absolute URL. It's tested and seems to work just fine.

I also took the liberty of removing the tab character and replacing them with 4 whitespaces.

Hope you find this, or parts of this, useful!