### PR TITLE
add CodeSignatureVerifier and fix downloader to macos.dmg

### DIFF
--- a/Gephi/Gephi.download.recipe
+++ b/Gephi/Gephi.download.recipe
@@ -1,58 +1,57 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>Description</key>
-	<string>Downloads the latest verison of Gephi</string>
-	<key>Identifier</key>
-	<string>com.github.joshua-d-miller.download.gephi</string>
-	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>Gephi</string>
+		<key>Description</key>
+		<string>Downloads the latest verison of Gephi</string>
+		<key>Identifier</key>
+		<string>com.github.joshua-d-miller.download.gephi</string>
+		<key>Input</key>
+		<dict>
+			<key>NAME</key>
+			<string>Gephi</string>
+		</dict>
+		<key>USER_AGENT</key>
+		<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
+		<key>MinimumVersion</key>
+		<string>0.6.1</string>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Processor</key>
+				<string>GitHubReleasesInfoProvider</string>
+				<key>Arguments</key>
+				<dict>
+					<key>github_repo</key>
+					<string>gephi/gephi</string>
+				</dict>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>URLDownloader</string>
+				<key>Arguments</key>
+				<dict>
+					<key>url</key>
+					<string>%url%</string>
+					<key>filename</key>
+					<string>%NAME%.dmg</string>
+				</dict>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>EndOfCheckPhase</string>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>CodeSignatureVerifier</string>
+				<key>Arguments</key>
+				<dict>
+					<key>input_path</key>
+					<string>%RECIPE_CACHE_DIR%/%NAME%.dmg/%NAME%.app</string>
+					<key>requirement</key>
+					<string>"com.apple.sh" and anchor apple designated => identifier "org.gephi" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3D8H75J8UL"</string>
+				</dict>
+			</dict>
+		</array>
 	</dict>
-            <key>USER_AGENT</key>
-            <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
-	<key>MinimumVersion</key>
-	<string>0.5.0</string>
-	<key>Process</key>
-	<array>
-                <dict>
-                    <key>Processor</key>
-                    <string>GitHubReleasesInfoProvider</string>
-                    <key>Arguments</key>
-                    <dict>
-                        <key>github_repo</key>
-                        <string>gephi/gephi</string>
-                    </dict>
-                </dict>
-                <dict>
-        	       <key>Processor</key>
-        	       <string>URLDownloader</string>
-        	       <key>Arguments</key>
-        	       <dict>
-        		  <key>url</key>
-        		  <string>%url%</string>
-        		  <key>filename</key>
-        		  <string>%NAME%.dmg</string>
-        	       </dict>
-                </dict>
-	   <dict>
-	       <key>Processor</key>
-	       <string>EndOfCheckPhase</string>
-	   </dict>
-	   <dict>
-    		<key>Processor</key>
-    		<string>CodeSignatureVerifier</string>
-    		<key>Arguments</key>
-    		<dict>
-        		<key>input_path</key>
-        		<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
-        		<key>requirement</key>
-        		<string>identifier "com.apple.sh" and anchor apple
-designated => identifier "org.gephi" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3D8H75J8UL"</string>
-    		</dict>
-    	   </dict>	
-	</array>
-</dict>
 </plist>

--- a/Gephi/Gephi.download.recipe
+++ b/Gephi/Gephi.download.recipe
@@ -49,7 +49,7 @@
 					<key>input_path</key>
 					<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%NAME%.app</string>
 					<key>requirement</key>
-					<string>"com.apple.sh" and anchor apple designated => identifier "org.gephi" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3D8H75J8UL"</string>
+					<string>identifier "org.gephi" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3D8H75J8UL"</string>
 				</dict>
 			</dict>
 		</array>

--- a/Gephi/Gephi.download.recipe
+++ b/Gephi/Gephi.download.recipe
@@ -41,6 +41,18 @@
 	       <key>Processor</key>
 	       <string>EndOfCheckPhase</string>
 	   </dict>
+	   <dict>
+    		<key>Processor</key>
+    		<string>CodeSignatureVerifier</string>
+    		<key>Arguments</key>
+    		<dict>
+        		<key>input_path</key>
+        		<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+        		<key>requirement</key>
+        		<string>identifier "com.apple.sh" and anchor apple
+designated => identifier "org.gephi" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3D8H75J8UL"</string>
+    		</dict>
+    	   </dict>	
 	</array>
 </dict>
 </plist>

--- a/Gephi/Gephi.download.recipe
+++ b/Gephi/Gephi.download.recipe
@@ -22,6 +22,9 @@
 				<string>GitHubReleasesInfoProvider</string>
 				<key>Arguments</key>
 				<dict>
+					<key>asset_regex</key>
+					<!--Change regex to match linux.tar.gz or windows.exe-->
+					<string>(gephi-[0-9\.]+-macos.dmg)</string>
 					<key>github_repo</key>
 					<string>gephi/gephi</string>
 				</dict>

--- a/Gephi/Gephi.download.recipe
+++ b/Gephi/Gephi.download.recipe
@@ -47,7 +47,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>input_path</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%.dmg/%NAME%.app</string>
+					<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%NAME%.app</string>
 					<key>requirement</key>
 					<string>"com.apple.sh" and anchor apple designated => identifier "org.gephi" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3D8H75J8UL"</string>
 				</dict>


### PR DESCRIPTION
Hi Joshua,

We're using this recipe at our company and liked to add CodeSignatureVerifier. We are using it for Munki (on Mac) so also added a regex to GitHubReleasesInfoProvider to get the macos.dmg
Please accept this humble update :-)

kind regards,
Frank