### PR TITLE
The previous command would return 1 if Office 2011 was not installed.

### DIFF
--- a/Mendeley/Mendeley.munki.recipe
+++ b/Mendeley/Mendeley.munki.recipe
@@ -28,11 +28,11 @@
     		<string>%NAME%</string>
             <key>postinstall_script</key>
             <string>#!/bin/bash
-            # Mircosoft Word 2011 Plugin for Mendeley
-            # Last Updated April 10, 2014 - Joshua D. Miller
-            # Set Permissions to allow the Mendeley Word Plugin to Install
-            [ -e /Applications/Microsoft\ Office\ 2011/ ] &amp;&amp; chmod o+w /Applications/Microsoft\ Office\ 2011/Office/Startup/Word
-            </string>
+# Mircosoft Word 2011 Plugin for Mendeley
+# Last Updated April 10, 2014 - Joshua D. Miller
+# Set Permissions to allow the Mendeley Word Plugin to Install
+[ ! -e /Applications/Microsoft\ Office\ 2011/ ] || chmod o+w /Applications/Microsoft\ Office\ 2011/Office/Startup/Word
+</string>
             <key>display_name</key>
             <string>%NAME%</string>
             <key>postuninstall_script</key>


### PR DESCRIPTION
The previous command would return exit 1 if Office 2011 was not installed.
We now return 0 if Office is not found or the exit code of `chmod o+w /Applications/Microsoft\ Office\ 2011/Office/Startup/Word`