### PR TITLE
Updated regex to account for major version changes

### DIFF
--- a/Adobe/AdobeAcrobatDCUpdate.munki.recipe
+++ b/Adobe/AdobeAcrobatDCUpdate.munki.recipe
@@ -48,7 +48,7 @@
                 <key>url</key>
                 <string>https://armmf.adobe.com/arm-manifests/mac/AcrobatDC/acrobat/current_version.txt</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;version&gt;15.*)</string>
+                <string>(?P&lt;version&gt;[0-9]*\.[0-9*?\.[0-9]*)</string>
             </dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
Was searching for 15, but now it's on 17. Let's just get the whole string to be the version.