### PR TITLE
Update Zotero download recipe

### DIFF
--- a/Zotero/Zotero.download.recipe
+++ b/Zotero/Zotero.download.recipe
@@ -17,22 +17,11 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>https://www.zotero.org/download/</string>
-				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;download.zotero.org/standalone/.*?/Zotero-.*?\.dmg)</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://%url%</string>
+				<string>https://www.zotero.org/download/client/dl?channel=release&amp;platform=mac</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
Based on developer feedback, there is no need to scrape the download page anymore. There is a persistent url that will provide the latest installer: https://www.zotero.org/download/client/dl?channel=release&platform=mac