### PR TITLE
Update postinstall and postuninstall scripts for Word 2016

### DIFF
--- a/Zotero/Zotero.munki.recipe
+++ b/Zotero/Zotero.munki.recipe
@@ -14,6 +14,11 @@
         <string>Zotero</string>
     	<key>pkginfo</key>
     	<dict>
+			<key>blocking_applications</key>
+			<array>
+				<string>Microsoft Word</string>
+				<string>Zotero</string>
+			</array>
     		<key>catalogs</key>
     		<array>
     			<string>testing</string>

--- a/Zotero/Zotero.munki.recipe
+++ b/Zotero/Zotero.munki.recipe
@@ -34,6 +34,19 @@
             # Last Updated April 10, 2014 - Joshua D. Miller
             # Set Permissions to allow the Zotero Word Plugin to Install
             [ ! -e /Applications/Microsoft\ Office\ 2011/ ] || chmod o+w /Applications/Microsoft\ Office\ 2011/Office/Startup/Word
+            
+            # Install script Microsoft Word 2016 Plugin for Zotero
+            # Check if Word 2016 is installed
+            if [ -e /Applications/Microsoft\ Word.app ]; then
+            echo "Word 2016 detected. Installing Zotero Word template."
+            # Get logged in user
+            loggedInUser=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in   [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+            echo "Logged in user is" $loggedInUser
+            # Copy Zotero.dotm to Word 2016 Startup directory
+            /bin/cp /Applications/Zotero.app/Contents/Resources/extensions/zoteroMacWordIntegration@zotero.org/install/Zotero.dotm /Users/$loggedInUser/Library/Group\ Containers/UBF8T346G9.Office/User\ Content.localized/Startup.localized/Word/
+            else echo "Word 2016 not found. Skipping installation of Zotero Word template."
+            fi
+            exit 0
             </string>
             <key>display_name</key>
             <string>%NAME%</string>
@@ -45,6 +58,18 @@
             [ -e /Applications/Microsoft\ Office\ 2011/Office/Word/Startup/Zotero.dot ] &amp;&amp; rm /Applications/Microsoft\ Office\ 2011/Office/Startup/Word/Zotero.dot
             # Restore Permissions on the folder /Applications/Microsoft Office 2011/Office/Startup/Word/
             [ ! -e /Applications/Microsoft\ Office\ 2011/ ] || chmod o-w /Applications/Microsoft\ Office\ 2011/Office/Startup/Word
+			
+			# Uninstall script for Microsoft Word 2016 Plugin for Zotero
+            # Get logged in user
+            loggedInUser=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in   [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+            echo "Logged in user is" $loggedInUser
+            echo "Checking for existence of Zotero.dotm"
+            if [ -e /Users/$loggedInUser/Library/Group\ Containers/UBF8T346G9.Office/User\ Content.localized/Startup.localized/Word/Zotero.dotm ]; then
+            echo "Zotero.dotm found. Attempting removal."
+            /bin/rm /Users/$loggedInUser/Library/Group\ Containers/UBF8T346G9.Office/User\ Content.localized/Startup.localized/Word/Zotero.dotm
+            else echo "Zotero.dotm not found. Skipping attempted removal."
+            fi
+            exit 0
             </string>
             <key>unattended_install</key>
             <true/>


### PR DESCRIPTION
Hi there,

Issue:
* Zotero is installed on a system with Word 2016.
* On launch, Zotero detects Word 2016, and copies the appropriate `Zotero.dotm` template to the relevant `Group Container` in the user home directory.
* If Zotero.app is removed (either manually or via Munki), this template is not removed with it.
* When Word is launched, the Zotero button is still present in the ribbon, but is not functional.
* If reinstalled, on first launch, Zotero does not recreate the `Zotero.dotm` template in the user home directory.

I've updated the scripts to mitigate this, and this has worked in my testing.

I've also noticed the following:
* If open during an uninstall attempt, Munki does not detect Zotero as running.
* If open during an uninstall attempt, the Zotero ribbon item is not removed from Word 2016 until the app is relaunched.

I've added both as `blocking_applications` to remedy this.