### PR TITLE
Change unattended_install key

### DIFF
--- a/Zotero/Zotero.munki.recipe
+++ b/Zotero/Zotero.munki.recipe
@@ -77,7 +77,7 @@
             exit 0
             </string>
             <key>unattended_install</key>
-            <true/>
+            <false/>
     	</dict>
     </dict>
     <key>MinimumVersion</key>


### PR DESCRIPTION
Recently implemented use of `blocking_applications` means we should change `unattended_install` to `false`