### PR TITLE
Updated the Identifier for the new NVivo recipe

### DIFF
--- a/NVivo/NVivo.download.recipe
+++ b/NVivo/NVivo.download.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads the latest version of the specified MAJOR_VERSION of NVivo.</string>
     <key>Identifier</key>
-    <string>com.github.joshua-d-miller.download.nvivo11</string>
+    <string>com.github.joshua-d-miller.download.nvivo</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>


### PR DESCRIPTION
This recipe has a duplicate identifier as the original NVivo11 recipe.