### PR TITLE
Update Stencyl recipes

### DIFF
--- a/Stencyl/Stencyl.download.recipe
+++ b/Stencyl/Stencyl.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>http://www.stencyl.com/download/get/mac/</string>
+		<string>http://mario.stencyl.net/public/Stencyl-full.dmg</string>
 		<key>NAME</key>
 		<string>Stencyl</string>
 	</dict>
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.zip</string>
+				<string>%NAME%.dmg</string>
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 			</dict>
@@ -37,23 +37,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%pathname%/%NAME%/%NAME%.app</string>
 				<key>requirement</key>
-				<string>identifier "com.stencyl.Stencyl" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = KRL5WPQT49</string>
+				<string>identifier "com.stencyl.Stencyl" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = XQ3UWKJ48P</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
@@ -62,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/%NAME%/%NAME%.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>

--- a/Stencyl/Stencyl.munki.recipe
+++ b/Stencyl/Stencyl.munki.recipe
@@ -12,6 +12,8 @@
 		<string>apps/stencyl</string>
 		<key>NAME</key>
 		<string>Stencyl</string>
+		<key>DESTINATION_PATH</key>
+		<string>/Applications</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -26,10 +28,21 @@
 			<string>Multimedia</string>
 			<key>display_name</key>
 			<string>Stencyl</string>
+			<key>minimum_os_version</key>
+			<string>10.10</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
 			<true/>
+			<key>items_to_copy</key>
+			<array>
+				<dict>
+					<key>destination_path</key>
+					<string>%DESTINATION_PATH%</string>
+					<key>source_item</key>
+					<string>Stencyl</string>
+				</dict>
+	    	</array>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
@@ -41,13 +54,47 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%%DESTINATION_PATH%/Stencyl</string>
+				<key>overwrite</key>
+				<true/>
+          		<key>source_path</key>
+          		<string>%pathname%/Stencyl</string>
+          	</dict>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+          		<key>installs_item_paths</key>
+          		<array>
+            		<string>%DESTINATION_PATH%/Stencyl/Stencyl.app</string>
+				</array>
+          	</dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+          		<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
+				<key>overwrite</key>
+				<true/>
+          		<key>source_path</key>
+          		<string>%pathname%</string>
 			</dict>
 			<key>Processor</key>
-			<string>DmgCreator</string>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict/>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
@@ -64,15 +111,26 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>munkiimport_appname</key>
+				<string>Stencyl</string>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
-				<key>version_comparison_key</key>
-				<string>CFBundleVersion</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
It appears that with version 4 (released in Feb.) the app is now distributed in a DMG instead of a ZIP file and the code signature changed.  Updated the download recipe accordingly.

I had previously been using the munki recipe in my environment, but kept getting duplicate entries (__1) in my munki_repo.  Additionally, the current recipe only copies the Stencyl app and not the the entire Stencyl directory, which includes a number of other pertinent resources.  As such, I updated & thoroughly tested the new munki recipe to include this entire Stencyl folder & verified subsequent runs do not create duplicate files for the same version in the munki_repo.

Full list of changes & reasoning are in my commit notes.

LMK what you think.