### PR TITLE
Update postuninstall script for mendeley

### DIFF
--- a/Mendeley/Mendeley.munki.recipe
+++ b/Mendeley/Mendeley.munki.recipe
@@ -68,20 +68,17 @@ fi</string>
             <string>%NAME%</string>
             <key>postuninstall_script</key>
             <string>#!/bin/bash
-
-# Get logged in user
-
-loggedInUser=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
-
-# Get plugin directory path
-
-pluginDirectory=/Users/$loggedInUser/Library/Group\ Containers/UBF8T346G9.Office/User\ Content.localized/Startup.localized/Word
-
-# Remove installed Mendeley plugins
-
-/bin/rm "$pluginDirectory"/Mendeley*
-
-exit 0</string>
+pluginDirectory="Library/Group Containers/UBF8T346G9.Office/User Content.localized/Startup.localized/Word"
+for user in /Users/*;do
+    if [[ -d "$user/$pluginDirectory" ]];then
+        for mendeley_plugin in "$user/$pluginDirectory"/Mendeley-word*;do
+            if [[ -e "$mendeley_plugin" ]];then
+                echo "Removing Mendeley Word Plugin: $mendeley_plugin"
+                rm -rf "$mendeley_plugin"
+            fi
+        done
+    fi
+done</string>
     		<key>unattended_install</key>
     		<true/>
     	</dict>


### PR DESCRIPTION
Hey @joshua-d-miller 

Thank you very much for all your great autopkg recipes.

I noticed that the `postuninstall_script` for mendeley only takes into account the logged in user - which might not be the only one using the mendeley plugin.

I updated the script and it would be great if you could take a look at it.

Best regards,
@aschwanb 