### PR TITLE
Update download link to new URL

### DIFF
--- a/Dashlane/Dashlane.download.recipe
+++ b/Dashlane/Dashlane.download.recipe
@@ -23,7 +23,7 @@
         	<key>Arguments</key>
         	<dict>
         		<key>url</key>
-        		<string>https://www.dashlane.com/directdownload/</string>
+        		<string>https://www.dashlane.com/download?forceArchive=true</string>
                 <key>request_headers</key>
                 <dict>
                         <key>user-agent</key>


### PR DESCRIPTION
The previous link, https://www.dashlane.com/directdownload, now only downloads the installer rather than the full Dashlane app. The new URL supplied by Dashlane support is https://www.dashlane.com/download?forceArchive=true. I've tried this and it downloads the Dashlane app as a disk image.