### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Box/BoxNotes.munki.recipe
+++ b/Box/BoxNotes.munki.recipe
@@ -84,7 +84,7 @@
             <key>Arguments</key>
             <dict>
         		<key>dmg_root</key>
-        		<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+        		<string>%RECIPE_CACHE_DIR%/Box Notes.app</string>
         		<key>dmg_path</key>
         		<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
         	</dict>

--- a/ChronoViz/ChronoViz.munki.recipe
+++ b/ChronoViz/ChronoViz.munki.recipe
@@ -57,7 +57,7 @@
             <key>Arguments</key>
             <dict>
                 <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/ChronoViz.app</string>
                 <key>dmg_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
             </dict>

--- a/Discord/Discord.download.recipe
+++ b/Discord/Discord.download.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Discord.app</string>
 				<key>requirement</key>
 				<string>identifier "com.hnc.Discord" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "53Q6R32WPB"</string>
 			</dict>

--- a/Gephi/Gephi.download.recipe
+++ b/Gephi/Gephi.download.recipe
@@ -50,7 +50,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>input_path</key>
-					<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%NAME%.app</string>
+					<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Gephi.app</string>
 					<key>requirement</key>
 					<string>identifier "org.gephi" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3D8H75J8UL"</string>
 				</dict>

--- a/Stencyl/Stencyl.download.recipe
+++ b/Stencyl/Stencyl.download.recipe
@@ -43,7 +43,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%/%NAME%.app</string>
+				<string>%pathname%/%NAME%/Stencyl.app</string>
 				<key>requirement</key>
 				<string>identifier "com.stencyl.Stencyl" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = XQ3UWKJ48P</string>
 			</dict>
@@ -54,7 +54,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/%NAME%/Stencyl.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.