### PR TITLE
Update Fathom.download.recipe

### DIFF
--- a/Fathom/Fathom.download.recipe
+++ b/Fathom/Fathom.download.recipe
@@ -3,11 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest verison of Fathom</string>
+	<string>Downloads the latest version of Fathom.</string>
 	<key>Identifier</key>
 	<string>com.github.joshua-d-miller.download.fathom</string>
 	<key>Input</key>
 	<dict>
+        <key>DOWNLOAD_URL</key>
+        <string>https://fathom.concord.org/wp-content/uploads/software/fathom-installers.zip</string>
 		<key>NAME</key>
 		<string>Fathom</string>
 	</dict>
@@ -16,31 +18,76 @@
 	<key>Process</key>
 	<array>
         <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>http://http://concord.org/fathom-dynamic-data-software</string>
-                <key>re_pattern</key>
-                <string>(?P&lt;url&gt;http://concord\.org/sites/default/files/downloads/software/fathom/Fathom.*?\.dmg)</string>
-            </dict>
-        </dict>
-        <dict>
         	<key>Processor</key>
         	<string>URLDownloader</string>
         	<key>Arguments</key>
         	<dict>
         		<key>url</key>
-        		<string>http://%url%</string>
+        		<string>%DOWNLOAD_URL%</string>
         		<key>filename</key>
-        		<string>%NAME%.dmg</string>
+        		<string>%NAME%.zip</string>
         	</dict>
         </dict>
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <key>source_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/fathom-installers/*.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>Copier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg/Fathom */Fathom.app</string>
+                <key>requirement</key>
+                <string>identifier "org.concord.fathom" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T8HS8WBPPQ</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg/Fathom */Fathom.app/Contents/Info.plist</string>
+            </dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg/%dmg_found_filename%</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleVersion</key>
+                    <string>version</string>
+                    <key>CFBundleShortVersionString</key>
+                    <string>fathom_dir</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+        </dict>             
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
- Fix spelling of version in description
- Add DOWNLOAD_URL
- Add Unarchiver, as download url is a ZIP that contains both a DMG and EXE
- Add Copier to copy DMG to root RECIPE_CACHE_DIR get user-friendly DMG filename for processing
- Add CodeSignatureVerifier
- Add FileFinder to get glob to Info.plist
- Add PlistReader to collect both the version (at CFBundleVersion) and app's contained folder name (which matches the CFBundleShortVersionString) for use by other recipes

Working on a munki recipe in my recipe repo