### PR TITLE
Update LogitechOptions.munki.recipe

### DIFF
--- a/Logitech/LogitechOptions.munki.recipe
+++ b/Logitech/LogitechOptions.munki.recipe
@@ -8,6 +8,8 @@
     <string>com.github.joshua-d-miller.autopkg.munki.logitechoptions</string>
     <key>Input</key>
     <dict>
+        <key>MUNKI_CATEGORY</key>
+        <string>Peripherals</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/logitech</string>
         <key>NAME</key>
@@ -19,19 +21,17 @@
     			<string>testing</string>
     		</array>
             <key>category</key>
-            <string>Peripherals</string>
+            <string>%MUNKI_CATEGORY%</string>
             <key>developer</key>
             <string>Logitech International S.A.</string>
             <key>display_name</key>
             <string>Logitech Options</string>
-            <key>RestartAction</key>
-            <string>RequireRestart</string>
     	    <key>description</key>
     	    <string>Logitech Options lets you customize gesture controls for Logitech touch products. It also adds enhanced key functions for Logitech keyboards, and notification for device-specific status features such as battery level, key backlighting level, and Caps Lock.</string>
             <key>name</key>
             <string>%NAME%</string>
-            <key>display_name</key>
-            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
     	</dict>
     </dict>
     <key>MinimumVersion</key>

--- a/Logitech/LogitechOptions.munki.recipe
+++ b/Logitech/LogitechOptions.munki.recipe
@@ -54,30 +54,10 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>input_plist_path</key>
-                <string>%found_filename%/Contents/Info.plist</string>
-            </dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/LogiMgr/</string>
-                </array>
-            </dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>flat_pkg_path</key>
                 <string>%RECIPE_CACHE_DIR%/Logitech Options.mpkg</string>
                 <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/Unpack/</string>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
             </dict>
             <key>Processor</key>
             <string>FlatPkgUnpacker</string>
@@ -85,21 +65,10 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/application_payload</string>
-                <key>pkgdirs</key>
-                <dict/>
-            </dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/Unpack/LogiMgrComponent.pkg/Payload</string>
+                <string>%RECIPE_CACHE_DIR%/unpack/LogiMgrComponent.pkg/Payload</string>
                 <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/application_payload</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
                 <key>purge_destination</key>
                 <true/>
             </dict>
@@ -109,8 +78,24 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Logi Options.app/Contents/Info.plist</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleShortVersionString</key>
+                    <string>version</string>
+                    <key>LSMinimumSystemVersion</key>
+                    <string>min_os_vers</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/application_payload</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
                 <key>installs_item_paths</key>
                 <array>
                     <string>/Applications/Logi Options.app</string>
@@ -132,7 +117,7 @@
                     <key>version</key>
                     <string>%version%</string>
                     <key>minimum_os_version</key>
-                    <string>10.10.0</string>
+                    <string>%min_os_vers%</string>
                 </dict>
             </dict>
             <key>Processor</key>
@@ -148,6 +133,19 @@
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                    <string>%RECIPE_CACHE_DIR%/LogiMgr</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Goal of these updates is to simplify a bit & remove hard-coded minimum os version, as this can change over time.