### PR TITLE
changed the regex and tested

### DIFF
--- a/DYMO/DYMOLabel.download.recipe
+++ b/DYMO/DYMOLabel.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>http://www.dymo.com/en-US/online-support/dymo-user-guides</string>
                 <key>re_pattern</key>
-                <string>http://download.dymo.com/dymo/Software/Mac/DL.*?Setup\.(?P&lt;build&gt;.*?)\.dmg</string>
+                <string>download.dymo.com/dymo/Software/Mac/DL.*?Setup\.(?P&lt;build&gt;.*?)\.dmg</string>
             </dict>
         </dict>
         <dict>
@@ -34,7 +34,7 @@
                 <key>url</key>
                 <string>http://www.dymo.com/en-US/online-support/dymo-user-guides</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;http://download.dymo.com/dymo/Software/Mac/DLS.*?Setup\..*?\.dmg)</string>
+                <string>(?P&lt;url&gt;download.dymo.com/dymo/Software/Mac/DLS.*?Setup\..*?\.dmg)</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
previously: "URLTextSearcher: Error: No match found on URL"

after fix:
```
franklaptop:Desktop frank$ autopkg run dymo.download.recipe
Processing dymo.download.recipe...
WARNING: dymo.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...

The following new items were downloaded:
    Download Path
    -------------
    /Users/frank/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.dymolabel/downloads/DymoLabel-8.7.3.dmg
```