### PR TITLE
Switch from CURL* back to URL* processors

### DIFF
--- a/Dashlane/Dashlane.download.recipe
+++ b/Dashlane/Dashlane.download.recipe
@@ -19,7 +19,7 @@
 	<array>
         <dict>
         	<key>Processor</key>
-        	<string>CURLDownloader</string>
+        	<string>URLDownloader</string>
         	<key>Arguments</key>
         	<dict>
         		<key>url</key>

--- a/Josh Jacob/TNEFsEnough.download.recipe
+++ b/Josh Jacob/TNEFsEnough.download.recipe
@@ -28,7 +28,7 @@
             </dict>
             <dict>
         	   <key>Processor</key>
-        	   <string>CURLDownloader</string>
+        	   <string>URLDownloader</string>
         	   <key>Arguments</key>
         	   <dict>
         	       <key>url</key>

--- a/LyX/lyx.download.recipe
+++ b/LyX/lyx.download.recipe
@@ -28,7 +28,7 @@
         </dict>
         <dict>
         	<key>Processor</key>
-        	<string>CURLDownloader</string>
+        	<string>URLDownloader</string>
         	<key>Arguments</key>
         	<dict>
         		<key>url</key>

--- a/Stencyl/Stencyl.download.recipe
+++ b/Stencyl/Stencyl.download.recipe
@@ -33,7 +33,7 @@
                 </dict>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
As of [AutoPkg 0.6.0](https://github.com/autopkg/autopkg/tree/v0.6.0), it's safe to switch back to the "standard" URLDownloader and URLTextSearcher processors.