### PR TITLE
Fixed download re_pattern

### DIFF
--- a/Unity3D/Unity3D.download.recipe
+++ b/Unity3D/Unity3D.download.recipe
@@ -27,7 +27,7 @@
                 <string>-L</string>
             </array>
             <key>re_pattern</key>
-            <string>(?P&lt;url&gt;https:\/\/beta\.unity3d\.com\/download\/.*\/MacEditorInstaller\/Unity\.pkg)</string>
+            <string>(?P&lt;url&gt;https:\/\/download\.unity3d\.com\/download_unity\/.*\/MacEditorInstaller\/Unity\.pkg)</string>
         </dict>
     </dict>
 	<dict>


### PR DESCRIPTION
Changed string to use get the correct URL for the package as it must have changed on Unity's side - a current example: https://download.unity3d.com/download_unity/b1a7e1fb4fa5/MacEditorInstaller/Unity.pkg

Old re_pattern was looking for `beta.unity3d.com/download/.....`