### PR TITLE
Search for Logitech Options url over HTTPS

### DIFF
--- a/Logitech/LogitechOptions.download.recipe
+++ b/Logitech/LogitechOptions.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://www.logitech.com/en-us/product/options</string>
+                <string>https://www.logitech.com/en-us/product/options</string>
                 <key>re_pattern</key>
                 <string>(?P&lt;url&gt;https:\/\/download01\.logi\.com\/web\/ftp\/pub\/techsupport\/options\/Options.*?\.zip)</string>
             </dict>


### PR DESCRIPTION
Found this while running `autopkg audit` on some overrides.