### PR TITLE
Add .DS_Store and *.pyc to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+*.pyc


### PR DESCRIPTION
Ensures that compiled Python bytecode files and macOS desktop services files don't appear in Git commits.

No changes made to AutoPkg recipes or processors.