### PR TITLE
Edit Zotero re_pattern to match version 6.0

### DIFF
--- a/Zotero/Zotero.download.recipe
+++ b/Zotero/Zotero.download.recipe
@@ -23,7 +23,7 @@
 				<key>url</key>
 				<string>https://www.zotero.org/support/changelog</string>
 				<key>re_pattern</key>
-				<string>Changes in (?P&lt;version&gt;\d\.\d\.\d{2}\.\d)</string>
+				<string>Changes in (?P&lt;version&gt;\d\.[0-9\.]+)</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
This pattern should keep matching future versions if they add a patch and build numbers.