### PR TITLE
Update Gephi.download asset_regex

### DIFF
--- a/Gephi/Gephi.download.recipe
+++ b/Gephi/Gephi.download.recipe
@@ -24,7 +24,7 @@
 				<dict>
 					<key>asset_regex</key>
 					<!--Change regex to match linux.tar.gz or windows.exe-->
-					<string>(gephi-[0-9\.]+-macos.dmg)</string>
+					<string>(gephi-[0-9\.]+-macos-x64.dmg)</string>
 					<key>github_repo</key>
 					<string>gephi/gephi</string>
 				</dict>


### PR DESCRIPTION
The latest Gephi release asset is named 

> gephi-0.9.3-macos-x64.dmg

which doesn't match the asset_regex in GitHubReleasesInfoProvider.
The recipe may need further adjustment if an arm version is released in the future.