### PR TITLE
Update Python path to reflect changes in macOS 12.3+

### DIFF
--- a/Mendeley/Mendeley.munki.recipe
+++ b/Mendeley/Mendeley.munki.recipe
@@ -40,7 +40,7 @@ fi
 
 # Get logged in user
 
-loggedInUser=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+loggedInUser=$(/usr/local/munki/munki-python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
 
 # Get Mendeley version
 

--- a/Zotero/Zotero.munki.recipe
+++ b/Zotero/Zotero.munki.recipe
@@ -39,13 +39,13 @@
             # Last Updated April 10, 2014 - Joshua D. Miller
             # Set Permissions to allow the Zotero Word Plugin to Install
             [ ! -e /Applications/Microsoft\ Office\ 2011/ ] || chmod o+w /Applications/Microsoft\ Office\ 2011/Office/Startup/Word
-            
+
             # Install script Microsoft Word 2016 Plugin for Zotero
             # Check if Word 2016 is installed
             if [ -e /Applications/Microsoft\ Word.app ]; then
             echo "Word 2016 detected. Installing Zotero Word template."
             # Get logged in user
-            loggedInUser=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in   [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+            loggedInUser=$(/usr/local/munki/munki-python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in   [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
             echo "Logged in user is" $loggedInUser
             # Copy Zotero.dotm to Word 2016 Startup directory
             /bin/cp /Applications/Zotero.app/Contents/Resources/extensions/zoteroMacWordIntegration@zotero.org/install/Zotero.dotm /Users/$loggedInUser/Library/Group\ Containers/UBF8T346G9.Office/User\ Content.localized/Startup.localized/Word/
@@ -63,10 +63,10 @@
             [ -e /Applications/Microsoft\ Office\ 2011/Office/Word/Startup/Zotero.dot ] &amp;&amp; rm /Applications/Microsoft\ Office\ 2011/Office/Startup/Word/Zotero.dot
             # Restore Permissions on the folder /Applications/Microsoft Office 2011/Office/Startup/Word/
             [ ! -e /Applications/Microsoft\ Office\ 2011/ ] || chmod o-w /Applications/Microsoft\ Office\ 2011/Office/Startup/Word
-			
+
 			# Uninstall script for Microsoft Word 2016 Plugin for Zotero
             # Get logged in user
-            loggedInUser=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in   [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+            loggedInUser=$(/usr/local/munki/munki-python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in   [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
             echo "Logged in user is" $loggedInUser
             echo "Checking for existence of Zotero.dotm"
             if [ -e /Users/$loggedInUser/Library/Group\ Containers/UBF8T346G9.Office/User\ Content.localized/Startup.localized/Word/Zotero.dotm ]; then


### PR DESCRIPTION
As of macOS Monterey 12.3, the version of Python 2 that shipped with macOS located at `/usr/bin/python` [has been removed](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes). More context can be found in some posts from Mac admins at the beginning of 2022, aggregated [here](https://scriptingosx.com/2022/03/macos-monterey-12-3-removes-python-2-link-collection/).

Since [version 2.0.2](https://github.com/autopkg/autopkg/releases/tag/v2.0.2), AutoPkg's installer has included its own Python 3 framework, symlinked from `/usr/local/autopkg/python`. Similarly, Munki ships with its own Python 3 framework, symlinked from `/usr/local/munki/munki-python`. This pull request adjusts the shebang and interpreter paths of processors, pre/post install scripts, and other files to replace `/usr/bin/python` with the AutoPkg or Munki Python 3 symlinks as appropriate.

NOTE: Because AutoPkg processors are imported as modules by AutoPkg and not executed directly, processors' shebang has no effect in normal usage. However: (a) some people execute processors directly during testing, and these tests won't work unless the shebang points to a valid Python 3, and (b) having instances of `/usr/bin/python` in the codebase could lead to confusion for people not deeply familiar with processor behavior.