### PR TITLE
RStudio download recipe fix

### DIFF
--- a/RStudio/RStudio.download.recipe
+++ b/RStudio/RStudio.download.recipe
@@ -15,7 +15,7 @@
         <key>SEARCH_PATTERN</key>
         <string>(?P&lt;dmg&gt;RStudio-(?P&lt;version&gt;([0-9.]+){1,3}?.*).dmg)</string>
         <key>DOWNLOAD_MIRROR</key>
-        <string>https://download1.rstudio.org/desktop/macos</string>
+        <string>https://download1.rstudio.org/electron/macos</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.5.1</string>


### PR DESCRIPTION
Update the download mirror to address issue #131 