### PR TITLE
JabraDirect and MacTeX

### DIFF
--- a/Jabra/JabraDirect.munki.recipe
+++ b/Jabra/JabraDirect.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Download the latest version of Jabra Direct and imports it into Munki.</string>
+    <string>Download the latest version of Jabra Direct and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.joshua-d-miller.autopkg.munki.jabradirect</string>
     <key>Input</key>
     <dict>
+    	<key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/jabradirect</string>
         <key>NAME</key>
@@ -33,7 +37,7 @@
     	</dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.joshua-d-miller.download.jabradirect</string>
     <key>Process</key>
@@ -105,6 +109,8 @@
                 <array>
                     <string>/Applications/Jabra Direct.app</string>
                 </array>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
             </dict>
             <key>Processor</key>
             <string>MunkiInstallsItemsCreator</string>

--- a/MacTeX/mactex.munki.recipe
+++ b/MacTeX/mactex.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Download the latest version of MacTeX and imports it into Munki.</string>
+    <string>Download the latest version of MacTeX and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.joshua-d-miller.autopkg.munki.MacTeX</string>
     <key>Input</key>
     <dict>
+    	<key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/mactex</string>
         <key>NAME</key>
@@ -40,7 +44,7 @@
     	</dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.joshua-d-miller.download.MacTeX</string>
     <key>Process</key>
@@ -101,6 +105,8 @@
                 <array>
                     <string>/Applications/TeX/LaTeXiT.app</string>
                 </array>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
             </dict>
             <key>Processor</key>
             <string>MunkiInstallsItemsCreator</string>


### PR DESCRIPTION
Hi, @joshua-d-miller 

The JabraDirect and MacTeX  Munki recipes currently don't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.15 and 10.9 respectively.

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose runs:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/joshua-d-miller-recipes/Jabra/JabraDirect.munki.recipe
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/joshua-d-miller-recipes/Jabra/JabraDirect.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/joshua-d-miller-recipes/Jabra/JabraDirect.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 17 Nov 2022 08:34:15 GMT
URLDownloader: Storing new ETag header: 0x8DAC8768301A961
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.jabradirect/downloads/Jabra Direct.dmg
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.jabradirect/downloads/Jabra Direct.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "JabraDirectSetup.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-11-14 16:37:28 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: GN Audio AS (55LV32M29R)
CodeSignatureVerifier:        Expires: 2027-07-02 12:19:47 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            2F F4 69 0C A7 7C F2 EF C6 33 20 86 DD 5C 0B 4F BD B6 A0 B4 83 32 
CodeSignatureVerifier:            D5 9E 80 D2 79 EA 13 C6 AC 46
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
EndOfCheckPhase
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.jabradirect/downloads/Jabra Direct.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.o80Mu3/JabraDirectSetup.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.jabradirect/Unpack/
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.jabradirect/application_payload/Applications
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.jabradirect/Unpack/JabraDirectSetup.unsigned.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.jabradirect/application_payload/Applications/Jabra Direct.app
Versioner
Versioner: Found version 6.5.31801 in file /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.jabradirect/application_payload/Applications/Jabra Direct.app/Contents/Info.plist
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '6.5.31801'} into pkginfo
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Jabra Direct.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.15
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '6.5.31801', 'installs': [{'CFBundleIdentifier': 'com.jabra.directonline', 'CFBundleName': 'Jabra Direct', 'CFBundleShortVersionString': '6.5.31801', 'CFBundleVersion': '6.5.31801', 'minosversion': '10.15', 'path': '/Applications/Jabra Direct.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.15'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/jabradirect/Jabra Direct-6.5.31801__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/jabradirect/Jabra Direct-6.5.31801__1.dmg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.jabradirect/receipts/JabraDirect.munki-receipt-20221223-154544.plist

The following new items were downloaded:
    Download Path                                                                                                      
    -------------                                                                                                      
    /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.jabradirect/downloads/Jabra Direct.dmg  

The following new items were imported into Munki:
    Name          Version    Catalogs  Pkginfo Path                                      Pkg Repo Path                                   Icon Repo Path  
    ----          -------    --------  ------------                                      -------------                                   --------------  
    Jabra Direct  6.5.31801  testing   apps/jabradirect/Jabra Direct-6.5.31801__1.plist  apps/jabradirect/Jabra Direct-6.5.31801__1.dmg  
```

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/joshua-d-miller-recipes/MacTeX/mactex.munki.recipe        
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/joshua-d-miller-recipes/MacTeX/mactex.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/joshua-d-miller-recipes/MacTeX/mactex.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 2022
URLTextSearcher: Found matching text (match): 2022
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 21 Mar 2022 21:00:51 GMT
URLDownloader: Storing new ETag header: "127bbbe1f-5dac0ca9af409"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.MacTeX/downloads/MacTeX.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "MacTeX.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-03-21 16:21:46 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Richard Koch (RBGCY5RJWM)
CodeSignatureVerifier:        Expires: 2027-02-27 20:17:21 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            69 C2 51 DA 42 2B CA FF 14 56 19 1C DC B4 3F C2 69 E0 8C A0 52 7D 
CodeSignatureVerifier:            9C 11 14 03 FB F1 53 21 88 D2
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '2022'} into pkginfo
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.MacTeX/downloads/MacTeX.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.MacTeX/Unpack/
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.MacTeX/application_payload/Applications
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.MacTeX/Unpack/GUI-Applications-Start.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.MacTeX/application_payload
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/TeX/LaTeXiT.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.9
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '2022', 'installs': [{'CFBundleIdentifier': 'fr.chachatelier.pierre.LaTeXiT', 'CFBundleShortVersionString': '2.16.4', 'CFBundleVersion': '2.16.4', 'minosversion': '10.9', 'path': '/Applications/TeX/LaTeXiT.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.9'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/mactex/MacTeX-2022.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/mactex/MacTeX-2022.pkg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.MacTeX/receipts/mactex.munki-receipt-20221223-160553.plist

The following new items were downloaded:
    Download Path                                                                                           
    -------------                                                                                           
    /Users/paul/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.MacTeX/downloads/MacTeX.pkg  

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                   Pkg Repo Path                Icon Repo Path  
    ----    -------  --------  ------------                   -------------                --------------  
    MacTeX  2022     testing   apps/mactex/MacTeX-2022.plist  apps/mactex/MacTeX-2022.pkg  
```