### PR TITLE
Update Zotero.munki.recipe

### DIFF
--- a/Zotero/Zotero.munki.recipe
+++ b/Zotero/Zotero.munki.recipe
@@ -45,7 +45,7 @@
             if [ -e /Applications/Microsoft\ Word.app ]; then
             echo "Word 2016 detected. Installing Zotero Word template."
             # Get logged in user
-            loggedInUser=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in   [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+            loggedInUser=$( echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }' )
             echo "Logged in user is" $loggedInUser
             # Copy Zotero.dotm to Word 2016 Startup directory
             /bin/cp /Applications/Zotero.app/Contents/Resources/extensions/zoteroMacWordIntegration@zotero.org/install/Zotero.dotm /Users/$loggedInUser/Library/Group\ Containers/UBF8T346G9.Office/User\ Content.localized/Startup.localized/Word/
@@ -66,7 +66,7 @@
 			
 			# Uninstall script for Microsoft Word 2016 Plugin for Zotero
             # Get logged in user
-            loggedInUser=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in   [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+            loggedInUser=$( echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }' )
             echo "Logged in user is" $loggedInUser
             echo "Checking for existence of Zotero.dotm"
             if [ -e /Users/$loggedInUser/Library/Group\ Containers/UBF8T346G9.Office/User\ Content.localized/Startup.localized/Word/Zotero.dotm ]; then


### PR DESCRIPTION
Changed to get logged in user with Bash instead of Python. Apple has removed local Python from macOS a while ago.

Python:
loggedInUser=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in   [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')

Bash:
loggedInUser=$( echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }' )