### PR TITLE
Adjust minimum AutoPkg version for MunkiOptionalReceiptEditor

### DIFF
--- a/Box/Box.munki.recipe
+++ b/Box/Box.munki.recipe
@@ -39,7 +39,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.joshua-d-miller.download.Box</string>
     <key>Process</key>


### PR DESCRIPTION
The MunkiOptionalReceiptEditor processor was included beginning in AutoPkg 2.7, so recipes that use this processor should have `MinimumVersion` set accordingly.