### PR TITLE
Update mactex.munki.recipe

### DIFF
--- a/Evernote/Evernote.download.recipe
+++ b/Evernote/Evernote.download.recipe
@@ -32,7 +32,7 @@
                         <string>%USER_AGENT%</string>
                 </dict>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/cdn[\d]\.evernote\.com\/boron\/mac\/builds\/Evernote-[\d.]+-.*\.dmg)</string>
+                <string>(npath: (?P&lt;url&gt;https:\/\/cdn[\d]\.evernote\.com\/boron\/mac\/builds\/Evernote-[\d.]+-.*)\.zip)</string>
             </dict>
         </dict>
         <dict>
@@ -41,7 +41,7 @@
         	<key>Arguments</key>
         	<dict>
         	   <key>url</key>
-        	   <string>%url%</string>
+        	   <string>%url%.dmg</string>
         	   <key>filename</key>
         	   <string>%NAME%.dmg</string>
         	</dict>

--- a/MacTeX/mactex.munki.recipe
+++ b/MacTeX/mactex.munki.recipe
@@ -103,7 +103,10 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
                 <string>%RECIPE_CACHE_DIR%/application_payload</string>
                 <key>installs_item_paths</key>
                 <array>
+                    <string>/Applications/TeX/BibDesk.app</string>
                     <string>/Applications/TeX/LaTeXiT.app</string>
+                    <string>/Applications/TeX/TeX Live Utility.app</string>
+                    <string>/Applications/TeX/TeXShop.app</string>
                 </array>
                 <key>derive_minimum_os_version</key>
                 <string>%DERIVE_MIN_OS%</string>


### PR DESCRIPTION
Added more installs_item_paths to accommodate situations where the individual apps (i.e. BibDesk, LaTeXiT, TLU, TeXShop) may exist separately in a Munki repo as updates for the macTeX suite. (macTeX 2023 wasn't being imported because the version of LaTeXit already existed here.)