### PR TITLE
Lyx: new universal binary and codesign certificate

### DIFF
--- a/LyX/lyx.download.recipe
+++ b/LyX/lyx.download.recipe
@@ -23,7 +23,7 @@
                 <key>url</key>
                 <string>https://www.lyx.org/Download</string>
                 <key>re_pattern</key>
-				<string>bin\/(?P&lt;versiondir&gt;.*?)\/(?P&lt;file&gt;LyX-.*?\+qt.*?-x86_64-cocoa\.dmg)</string>
+				<string>bin\/(?P&lt;versiondir&gt;.*?)\/(?P&lt;file&gt;LyX-.*?\+qt.*?-x86_64-arm64-cocoa\.dmg)</string>
             </dict>
         </dict>
         <dict>
@@ -45,7 +45,7 @@
                 <key>input_path</key>
                 <string>%pathname%/LyX.app</string>
                 <key>requirement</key>
-                <string>identifier "org.lyx.lyx" and certificate leaf = H"08a2c27dfa7e46463bc0dad278e5797b4aea3556"</string>
+                <string>identifier "org.lyx.lyx" and certificate leaf = H"bc48ff7941c33f70838298a129f92745a39e654b"</string>
             </dict>
         </dict>
 		<dict>


### PR DESCRIPTION
The Lyx recipe has been broken for a while now. It seems upstream released a combined x86_64_arm64 build and also changed the certificate. I verified with gpg and the published signatures on [lyx.org](https://www.lyx.org/Download#toc4) like this:

```
$ wget https://lyx.mirror.garr.it/bin/2.3.7/LyX-2.3.7+qt5-x86_64-arm64-cocoa.dmg
$ wget https://lyx.mirror.garr.it/bin/2.3.7/LyX-2.3.7+qt5-x86_64-arm64-cocoa.dmg.sig
$ gpg --recv-keys --keyserver keyserver.ubuntu.com FE66471B43559707AFDAD955DE7A44FAC7FB382D
$ gpg --verify LyX-2.3.7+qt5-x86_64-arm64-cocoa.dmg.sig
gpg: Signature made Wed Jan  4 19:39:57 2023 CET
gpg:                using RSA key FE66471B43559707AFDAD955DE7A44FAC7FB382D
gpg: Good signature from "LyX Release Manager (Signing LyX tarballs and binaries) <sanda@lyx.org>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: FE66 471B 4355 9707 AFDA  D955 DE7A 44FA C7FB 382D
```

```
$ hdiutil attach LyX-2.3.7+qt5-x86_64-arm64-cocoa.dmg
$ codesign --display -r- --deep -v /Volumes/LyX-2.3.7/LyX.app 2>&1 | tail -n1
designated => identifier "org.lyx.lyx" and certificate root = H"bc48ff7941c33f70838298a129f92745a39e654b"
```