### PR TITLE
KalturaCapture.download : Search for full download URL not just version

### DIFF
--- a/Kaltura/KalturaCapture.download.recipe
+++ b/Kaltura/KalturaCapture.download.recipe
@@ -31,8 +31,10 @@
                         <key>user-agent</key>
                         <string>%USER_AGENT%</string>
                 </dict>
+                <key>result_output_var_name</key>
+                <string>download_url</string>
                 <key>re_pattern</key>
-                <string>Kaltura\ Capture\ Version\ (?P&lt;version&gt;[\d]\.[\d]\.[\d.]+)</string>
+                <string>(https:\/\/cdnapisec.kaltura.com\/content\/static\/classroom\/v([\d]\.[\d]\.[\d.]+)\/KalturaCapture_([\d]\.[\d]\.[\d.]+).dmg)</string>
             </dict>
         </dict>
         <dict>
@@ -41,7 +43,7 @@
         	<key>Arguments</key>
         	<dict>
         	   <key>url</key>
-        	   <string>https://cdnapisec.kaltura.com/content/static/classroom/v%version%/KalturaCapture_%version%.dmg</string>
+               <string>%download_url%</string>
         	   <key>filename</key>
         	   <string>%NAME%.dmg</string>
         	</dict>


### PR DESCRIPTION
The KaltureCapture.download recipe was searching for the version on the release notes page and constructing the download URL using that version.  This technique breaks down when the latest release is for Windows and does not include macOS.

This pull request instead searches for a download URL of the correct file type (.dmg) 