### PR TITLE
Fix download pattern to match version-numbers from 1 to 3 digits

### DIFF
--- a/Mendeley/MendeleyReferenceManager.download.recipe
+++ b/Mendeley/MendeleyReferenceManager.download.recipe
@@ -34,7 +34,7 @@
                         <string>%USER_AGENT%</string>
                 </dict>
                 <key>re_pattern</key>
-                <string>(?P&lt;Version&gt;\d\.\d{2}\.\d\.dmg)</string>
+                <string>(?P&lt;Version&gt;\d\.\d{1,3}\.\d\.dmg)</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Here is a proposed fix for issue #156 - this fix should provide a more robust pattern for changing version-numbers on Mendeleys end.

The issue arrises because Mendeley Reference Manager went from version 2.99.0 to 2.100.0, thereby creating a 3-digit versioning-bit in the middle of the version-number.