### PR TITLE
Update Regex to ignore Windows only updates

### DIFF
--- a/Zotero/Zotero.download.recipe
+++ b/Zotero/Zotero.download.recipe
@@ -23,7 +23,7 @@
 				<key>url</key>
 				<string>https://www.zotero.org/support/changelog</string>
 				<key>re_pattern</key>
-				<string>Changes in ([0-9]+(\.[0-9]+)+) \([a-zA-Z]+ [0-9]+, [0-9]+\)</string>
+				<string>Changes in ([0-9]+(\.[0-9]+)+) \([a-zA-Z]+ [0-9]+, [0-9]+\)(?!((.|\n)*)Windows)</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
The most recent Zotero update was windows only, causing the recipe to fail.