### PR TITLE
Update Zotero.download.recipe

### DIFF
--- a/Zotero/Zotero.download.recipe
+++ b/Zotero/Zotero.download.recipe
@@ -21,9 +21,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://www.zotero.org/support/changelog</string>
+				<string>https://www.zotero.org/download/</string>
 				<key>re_pattern</key>
-				<string>Changes in ([0-9]+(\.[0-9]+)+) \([a-zA-Z]+ [0-9]+, [0-9]+\)</string>
+				<string>\"mac\":\"(.*?)\",</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Changes to check https://www.zotero.org/download/ for the version instead of https://www.zotero.org/support/changelog, as the latter is currently offering a version for which there is no download.