### PR TITLE
Update Zotero.munki.recipe

### DIFF
--- a/Zotero/Zotero.munki.recipe
+++ b/Zotero/Zotero.munki.recipe
@@ -48,7 +48,7 @@
             loggedInUser=$( echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }' )
             echo "Logged in user is" $loggedInUser
             # Copy Zotero.dotm to Word 2016 Startup directory
-            /bin/cp /Applications/Zotero.app/Contents/Resources/extensions/zoteroMacWordIntegration@zotero.org/install/Zotero.dotm /Users/$loggedInUser/Library/Group\ Containers/UBF8T346G9.Office/User\ Content.localized/Startup.localized/Word/
+            /bin/cp /Applications/Zotero.app/Contents/Resources/integration/word-for-mac/Zotero.dotm /Users/$loggedInUser/Library/Group\ Containers/UBF8T346G9.Office/User\ Content.localized/Startup.localized/Word/
             else echo "Word 2016 not found. Skipping installation of Zotero Word template."
             fi
             exit 0


### PR DESCRIPTION
In new Zotero release (7), the word plug-in has a new location: /Applications/Zotero.app/Contents/Resources/integration/word-for-mac/Zotero.dotm

Before it was: /Applications/Zotero.app/Contents/Resources/extensions/zoteroMacWordIntegration@zotero.org/install/Zotero.dotm