### PR TITLE
Update RStudio.download.recipe SEARCH_URL

### DIFF
--- a/RStudio/RStudio.download.recipe
+++ b/RStudio/RStudio.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>RStudio</string>
         <key>SEARCH_URL</key>
-        <string>https://www.rstudio.com/products/rstudio/download/#download</string>
+        <string>https://posit.co/download/rstudio-desktop/</string>
         <key>SEARCH_PATTERN</key>
         <string>(?P&lt;dmg&gt;RStudio-(?P&lt;version&gt;([0-9.]+){1,3}?.*).dmg)</string>
         <key>DOWNLOAD_MIRROR</key>


### PR DESCRIPTION
The primary web address for rstudio has changed to posit.co and so the search url has changed. For the moment the download mirror url remains the same.