### PR TITLE
Add variable for Installs Array application

### DIFF
--- a/MacTeX/mactex.munki.recipe
+++ b/MacTeX/mactex.munki.recipe
@@ -1,4 +1,4 @@
-´<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/MacTeX/mactex.munki.recipe
+++ b/MacTeX/mactex.munki.recipe
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+´<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -16,6 +16,8 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
         <string>apps/mactex</string>
         <key>NAME</key>
         <string>MacTeX</string>
+        <key>INSTALLS_ARRAY_APP</key>
+        <string>LaTeXiT</string>
     	<key>pkginfo</key>
     	<dict>
     		<key>catalogs</key>
@@ -103,7 +105,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
                 <string>%RECIPE_CACHE_DIR%/application_payload</string>
                 <key>installs_item_paths</key>
                 <array>
-                    <string>/Applications/TeX/LaTeXiT.app</string>
+                    <string>/Applications/TeX/%INSTALLS_ARRAY_APP%.app</string>
                 </array>
                 <key>derive_minimum_os_version</key>
                 <string>%DERIVE_MIN_OS%</string>


### PR DESCRIPTION
Would it be possible to add an variable, by which you could define (in your overdrive) from which app you want to create the installs array from?

Example in this pull request.