### PR TITLE
Deprecate TechsmithCapture recipes

### DIFF
--- a/Techsmith/TechsmithCapture.download.recipe
+++ b/Techsmith/TechsmithCapture.download.recipe
@@ -15,6 +15,15 @@
 	<string>2.0.0</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the TechSmithCapture recipes in the blackthroat-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
         <dict>
         	<key>Processor</key>
         	<string>URLDownloader</string>
@@ -28,6 +37,10 @@
         </dict>
 		<dict>
 			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
 			<dict>
@@ -36,10 +49,6 @@
 				<key>requirement</key>
 				<string>identifier "com.techsmith.relayrecorder" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TQL462TU8"</string>
 			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
The TechsmithCapture recipes in this recipe are not working, and are insufficiently distinct from similar recipes in the AutoPkg org to warrant the additional maintenance effort. This PR deprecates the TechsmithCapture recipes in this repo and points users to working alternatives in the blackthroat-recipes repo.
