### PR TITLE
Fix Geometer's SketchPad beta recipes

### DIFF
--- a/McGraw-Hill Education/Sketchpad-BETA.download.recipe
+++ b/McGraw-Hill Education/Sketchpad-BETA.download.recipe
@@ -18,71 +18,71 @@
 	<key>Process</key>
 	<array>
 		<dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%SEARCH_URL%</string>
-                <key>re_pattern</key>
-                <string>(?P&lt;url&gt;downloads\/GSP_(?P&lt;betaversion&gt;\d{4,})\.zip)</string>
-            </dict>
-        </dict>
-        <dict>
-        	<key>Processor</key>
-        	<string>URLDownloader</string>
-        	<key>Arguments</key>
-        	<dict>
-        	   <key>url</key>
-        	   <string>https://gsptest.scratchconsortium.com/%url%</string>
-        	   <key>filename</key>
-        	   <string>%NAME%.zip</string>
-        	</dict>
-        </dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%SEARCH_URL%</string>
+				<key>re_pattern</key>
+				<string>(?P&lt;url&gt;downloads\/GSP_(?P&lt;betaversion&gt;\d{4,})\.zip)</string>
+			</dict>
+		</dict>
 		<dict>
-        	<key>Processor</key>
-        	<string>Unarchiver</string>
-        	<key>Arguments</key>
-        	<dict>
-        		<key>purge_destination</key>
-        		<true/>
-        	</dict>
-        </dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+			   <key>url</key>
+			   <string>https://gsptest.scratchconsortium.com/%url%</string>
+			   <key>filename</key>
+			   <string>%NAME%.zip</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+			<key>Arguments</key>
+			<dict>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>FileMover</string>
 			<key>Arguments</key>
 			<dict>
 				<key>source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/GSP_%betaversion%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/GSP %betaversion%.app</string>
 				<key>target</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Sketchpad BETA %betaversion%.app</string>
 			</dict>
 		</dict>
 		<dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Sketchpad BETA *.app</string>
-                <key>requirement</key>
-                <string>anchor apple generic and identifier "com.kcptech.Sketchpad" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = S4CY52J26G)</string>
-            </dict>
-        </dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Sketchpad BETA %betaversion%.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.scratchconsortium.gsp" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = S4CY52J26G)</string>
+			</dict>
+		</dict>
 		<dict>
-        	<key>Processor</key>
-        	<string>DmgCreator</string>
-        	<key>Arguments</key>
-        	<dict>
-        		<key>dmg_root</key>
-        		<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-        		<key>dmg_path</key>
-        		<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-                <key>dmg_megabytes</key>
-                <string>500</string>
-        	</dict>
-        </dict>
+			<key>Processor</key>
+			<string>DmgCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>dmg_root</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>dmg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				<key>dmg_megabytes</key>
+				<string>500</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>


### PR DESCRIPTION
This PR adjusts the Geometer's SketchPad beta download recipe to reflect changes to the contents of the zip file that will be downloaded.

Verbose recipe run output:

```
% autopkg run -vvq 'McGraw-Hill Education/Sketchpad-BETA.download.recipe'
Processing McGraw-Hill Education/Sketchpad-BETA.download.recipe...
WARNING: McGraw-Hill Education/Sketchpad-BETA.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<url>downloads\\/GSP_(?P<betaversion>\\d{4,})\\.zip)',
           'url': 'https://gsptest.scratchconsortium.com/download.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): downloads/GSP_3058.zip
URLTextSearcher: Found matching text (betaversion): 3058
URLTextSearcher: Found matching text (match): downloads/GSP_3058.zip
{'Output': {'betaversion': '3058',
            'match': 'downloads/GSP_3058.zip',
            'url': 'downloads/GSP_3058.zip'}}
URLDownloader
{'Input': {'filename': 'Sketchpad.zip',
           'url': 'https://gsptest.scratchconsortium.com/downloads/GSP_3058.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 28 Aug 2024 22:02:52 GMT
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/downloads/Sketchpad.zip
{'Output': {'download_changed': True,
            'last_modified': 'Wed, 28 Aug 2024 22:02:52 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/downloads/Sketchpad.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/downloads/Sketchpad.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
Unarchiver
{'Input': {'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Sketchpad.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/downloads/Sketchpad.zip to ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/Sketchpad
{'Output': {}}
FileMover
{'Input': {'source': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/Sketchpad/GSP '
                     '3058.app',
           'target': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/Sketchpad/Sketchpad '
                     'BETA 3058.app'}}
FileMover: File ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/Sketchpad/GSP 3058.app moved to ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/Sketchpad/Sketchpad BETA 3058.app
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/Sketchpad/Sketchpad '
                         'BETA 3058.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.scratchconsortium.gsp" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = S4CY52J26G)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/Sketchpad/Sketchpad BETA 3058.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/Sketchpad/Sketchpad BETA 3058.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/Sketchpad/Sketchpad BETA 3058.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_megabytes': '500',
           'dmg_path': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/Sketchpad.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/Sketchpad'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/Sketchpad at ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/Sketchpad.dmg
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/receipts/Sketchpad-BETA.download-receipt-20241226-205357.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.sketchpadbeta/downloads/Sketchpad.zip
```
