### PR TITLE
Deprecate Prezi recipes

### DIFF
--- a/Prezi/Prezi.download.recipe
+++ b/Prezi/Prezi.download.recipe
@@ -17,6 +17,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Prezi Classic is no longer publicly downloadable. Consider switching to the Prezi Video recipes in the aanklewicz-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The Prezi Classic app is no longer publicly downloadable. This PR deprecates the Prezi recipes and points users to the Prezi Video recipes in the aanklewicz-recipes repo instead.