### PR TITLE
Deprecate Evernote recipes

### DIFF
--- a/Evernote/Evernote.download.recipe
+++ b/Evernote/Evernote.download.recipe
@@ -21,6 +21,15 @@
 	<array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Evernote recipes in the autopkg/recipes repo (https://github.com/autopkg/recipes/tree/master/Evernote). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The Evernote recipes in this repo are not currently functional, and are insufficiently distinct from the ones in the [autopkg/recipes](https://github.com/autopkg/recipes/tree/master/Evernote) repo to warrant separate maintenance. This PR deprecates the Evernote recipes and points users to alternatives.
