### PR TITLE
Fix DinoXcope recipes

### DIFF
--- a/DinoXcope/DinoXcope.download.recipe
+++ b/DinoXcope/DinoXcope.download.recipe
@@ -10,36 +10,25 @@
 	<dict>
 		<key>NAME</key>
 		<string>DinoXcope</string>
-        <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Safari/605.1.15</string>
-		<key>SEARCH_URL</key>
-		<string>https://www.dinolite.us/en/downloads</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.9</string>
-	<key>Process</key>
-	<array>
+    <key>Process</key>
+    <array>
         <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%SEARCH_URL%</string>
-                <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/www\.dinolite\.us\/dl\/archive\/DinoXcope_OSX_[\d.]+.dmg)</string>
-            </dict>
+        <key>Processor</key>
+        <string>URLDownloader</string>
+        <key>Arguments</key>
+        <dict>
+            <key>url</key>
+            <string>https://files.dinolite.us/downloads/software/dnx/latest/DinoXcope.dmg</string>
+            <key>filename</key>
+            <string>%NAME%.dmg</string>
+        </dict>
         </dict>
         <dict>
-    	   <key>Processor</key>
-    	   <string>URLDownloader</string>
-    	   <key>Arguments</key>
-    	   <dict>
-    	       <key>url</key>
-    	       <string>%url%</string>
-               <key>filename</key>
-               <string>%NAME%.dmg</string>
-    	   </dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>
@@ -52,10 +41,6 @@
                 <string>anchor apple generic and identifier "com.anmo.DinoXcope" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = TDSK62KZ54)</string>
             </dict>
         </dict>
-	    <dict>
-	        <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-	    </dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR adjusts the download page for DinoXcope, and moves EndOfCheckPhase to align with convention.

Verbose recipe run output:

```
% autopkg run -vvq 'DinoXcope/DinoXcope.download.recipe'
Processing DinoXcope/DinoXcope.download.recipe...
WARNING: DinoXcope/DinoXcope.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'DinoXcope.dmg',
           'url': 'https://files.dinolite.us/downloads/software/dnx/latest/DinoXcope.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 30 Aug 2024 15:49:13 GMT
URLDownloader: Storing new ETag header: "10bce0b-620e8886c083e"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.dinoxcope/downloads/DinoXcope.dmg
{'Output': {'download_changed': True,
            'etag': '"10bce0b-620e8886c083e"',
            'last_modified': 'Fri, 30 Aug 2024 15:49:13 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.dinoxcope/downloads/DinoXcope.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.dinoxcope/downloads/DinoXcope.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.dinoxcope/downloads/DinoXcope.dmg/DinoXcope.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.anmo.DinoXcope" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = TDSK62KZ54)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.dinoxcope/downloads/DinoXcope.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.SolfLi/DinoXcope.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.SolfLi/DinoXcope.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.SolfLi/DinoXcope.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.dinoxcope/receipts/DinoXcope.download-receipt-20241226-203414.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.dinoxcope/downloads/DinoXcope.dmg
```
