### PR TITLE
Fix Stencyl recipes for 4.x downloads

### DIFF
--- a/Stencyl/Stencyl.download.recipe
+++ b/Stencyl/Stencyl.download.recipe
@@ -15,29 +15,24 @@
 	<string>1.0.0</string>
 	<key>Process</key>
 	<array>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>http://www.stencyl.com/download/</string>
-                <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https:\/\/www\.stencyl\.com\/download\/get\/.*\/mac\.dmg)</string>
-            </dict>
-        </dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>https://community.stencyl.com/index.php/topic,5530.0.html</string>
+				<key>re_pattern</key>
+				<string>(https:\/\/www\.stencyl\.com\/download\/get\/.*\/mac\.dmg)</string>
+				<key>result_output_var_name</key>
+				<string>url</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
-				<key>url</key>
-				<string>%url%</string>
-                <key>request_headers</key>
-                <dict>
-                        <key>user-agent</key>
-                        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.94 Safari/537.36 Vivaldi/2.6.1566.40</string>
-                </dict>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
This PR adjusts the download page for Stencyl so that version 4.x downloads can still be retrieved.

However, note that the next version (5.x) of Stencyl is likely to be a "multiplatform" release with no Mac specific app. See the development release note on [this page](https://www.stencyl.com/download/).

Verbose recipe run output:

```
% autopkg run -vvq 'Stencyl/Stencyl.download.recipe'
Processing Stencyl/Stencyl.download.recipe...
WARNING: Stencyl/Stencyl.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(https:\\/\\/www\\.stencyl\\.com\\/download\\/get\\/.*\\/mac\\.dmg)',
           'result_output_var_name': 'url',
           'url': 'https://community.stencyl.com/index.php/topic,5530.0.html'}}
URLTextSearcher: Found matching text (url): https://www.stencyl.com/download/get/4.0.4/mac.dmg
{'Output': {'url': 'https://www.stencyl.com/download/get/4.0.4/mac.dmg'}}
URLDownloader
{'Input': {'filename': 'Stencyl.dmg',
           'url': 'https://www.stencyl.com/download/get/4.0.4/mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 06 Oct 2021 18:13:05 GMT
URLDownloader: Storing new ETag header: "51009c-12c22f6a-5cdb318f36e40"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.download.Stencyl/downloads/Stencyl.dmg
{'Output': {'download_changed': True,
            'etag': '"51009c-12c22f6a-5cdb318f36e40"',
            'last_modified': 'Wed, 06 Oct 2021 18:13:05 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.download.Stencyl/downloads/Stencyl.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.download.Stencyl/downloads/Stencyl.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.download.Stencyl/downloads/Stencyl.dmg/Stencyl-*/Stencyl.app',
           'requirement': 'identifier "com.stencyl.Stencyl" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'XQ3UWKJ48P'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.download.Stencyl/downloads/Stencyl.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.BAt9sn/Stencyl-4.0.4-mac/Stencyl.app' matched from globbed '/private/tmp/dmg.BAt9sn/Stencyl-*/Stencyl.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.BAt9sn/Stencyl-4.0.4-mac/Stencyl.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.BAt9sn/Stencyl-4.0.4-mac/Stencyl.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.BAt9sn/Stencyl-4.0.4-mac/Stencyl.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.download.Stencyl/receipts/Stencyl.download-receipt-20241226-203028.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.download.Stencyl/downloads/Stencyl.dmg
```