### PR TITLE
Deprecate Amazon Music recipes

### DIFF
--- a/Amazon/AmazonMusic-jdm.download.recipe
+++ b/Amazon/AmazonMusic-jdm.download.recipe
@@ -18,6 +18,15 @@
 	<key>Process</key>
 	<array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the AmazonMusic recipes in the hansen-m-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
         	<key>Processor</key>
         	<string>URLDownloader</string>
         	<key>Arguments</key>


### PR DESCRIPTION
The Amazon Music recipe in this repo is broken, and is also redundant with the recipes in hansen-m-recipes. This PR deprecates the Amazon Music recipes and points users to the hansen-m-recipes alternatives.
