### PR TITLE
Add code signature verification for Geogebra

### DIFF
--- a/GeoGebra/GeoGebra.download.recipe
+++ b/GeoGebra/GeoGebra.download.recipe
@@ -17,48 +17,46 @@
 	<string>0.3.0</string>
 	<key>Process</key>
 	<array>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
-                <key>request_headers</key>
-                <dict>
-                        <key>user-agent</key>
-                        <string>%USER_AGENT%</string>
-                </dict>
-                <key>filename</key>
-                <string>%NAME%.zip</string>
-            </dict>
-        </dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
+				<key>request_headers</key>
+				<dict>
+						<key>user-agent</key>
+						<string>%USER_AGENT%</string>
+				</dict>
+				<key>filename</key>
+				<string>%NAME%.zip</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
 		<dict>
-        	<key>Processor</key>
-        	<string>Unarchiver</string>
-        	<key>Arguments</key>
-        	<dict>
-        		<key>purge_destination</key>
-        		<true/>
-        	</dict>
-        </dict>
-        <dict>
-        	<key>Processor</key>
-        	<string>DmgCreator</string>
-        	<key>Arguments</key>
-        	<dict>
-        		<key>dmg_root</key>
-        		<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-        		<key>dmg_path</key>
-        		<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-                <key>dmg_megabytes</key>
-                <string>500</string>
-        	</dict>
-        </dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+			<key>Arguments</key>
+			<dict>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/GeoGebra Classic 6.app</string>
+				<key>requirements</key>
+				<string>identifier "org.geogebra6.mac" and anchor apple generic and certificate leaf[subject.CN] = "Apple Distribution: Internationales GeoGebra Institut, \"IGI\" (T9W862P4D2)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/GeoGebra/GeoGebra.munki.recipe
+++ b/GeoGebra/GeoGebra.munki.recipe
@@ -39,6 +39,19 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DmgCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <key>dmg_megabytes</key>
+                <string>500</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>


### PR DESCRIPTION
This PR adds code signature verification to the Geogebra recipes, and moves the DmgCreator process into the Munki recipe that requires it.

Verbose recipe run output:

```
% autopkg run -vvq 'GeoGebra/GeoGebra.download.recipe'
Processing GeoGebra/GeoGebra.download.recipe...
WARNING: GeoGebra/GeoGebra.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
Use of undefined key in variable substitution: 'USER_AGENT'
{'Input': {'filename': 'GeoGebra.zip',
           'request_headers': {'user-agent': '%USER_AGENT%'},
           'url': 'https://download.geogebra.org/package/mac-port'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.geogebra/downloads/GeoGebra.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.geogebra/downloads/GeoGebra.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename GeoGebra.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.geogebra/downloads/GeoGebra.zip to ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.geogebra/GeoGebra
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.geogebra/GeoGebra/GeoGebra '
                         'Classic 6.app'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: WARNING: This recipe is using 'requirements' when it should be using 'requirement'. This will become an error in future versions of AutoPkg.
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.geogebra/GeoGebra/GeoGebra Classic 6.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.geogebra/GeoGebra/GeoGebra Classic 6.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.geogebra/GeoGebra/GeoGebra Classic 6.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_megabytes': '500',
           'dmg_path': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.geogebra/GeoGebra.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.geogebra/GeoGebra'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.geogebra/GeoGebra at ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.geogebra/GeoGebra.dmg
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.download.geogebra/receipts/GeoGebra.download-receipt-20241229-124913.plist

Nothing downloaded, packaged or imported.
```

