### PR TITLE
Change parent recipe of RStudio.munki

### DIFF
--- a/RStudio/RStudio.download.recipe
+++ b/RStudio/RStudio.download.recipe
@@ -18,10 +18,19 @@
         <string>https://download1.rstudio.org/electron/macos</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.5.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
-       <dict>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the RStudio recipes in the hansen-m-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>

--- a/RStudio/RStudio.munki.recipe
+++ b/RStudio/RStudio.munki.recipe
@@ -39,7 +39,7 @@
     <key>MinimumVersion</key>
     <string>0.2.9</string>
     <key>ParentRecipe</key>
-    <string>com.github.joshua-d-miller.download.RStudio</string>
+    <string>com.github.hansen-m.download.RStudio</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
This PR switches the parent recipe of RStudio.munki to the hansen-m download recipe, and deprecates the download recipe in this repo.

Verboose recipe run output:

```
% autopkg run -vvq RStudio.munki.recipe
Processing RStudio.munki.recipe...
WARNING: RStudio.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<dmg>RStudio-(?P<version>([0-9.]+){1,3}?.*).dmg)',
           'url': 'https://posit.co/download/rstudio-desktop/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (dmg): RStudio-2024.12.0-467.dmg
URLTextSearcher: Found matching text (version): 2024.12.0-467
URLTextSearcher: Found matching text (match): RStudio-2024.12.0-467.dmg
{'Output': {'dmg': 'RStudio-2024.12.0-467.dmg',
            'match': 'RStudio-2024.12.0-467.dmg',
            'version': '2024.12.0-467'}}
URLDownloader
{'Input': {'filename': 'RStudio.dmg',
           'url': 'https://download1.rstudio.org/electron/macos/RStudio-2024.12.0-467.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 16 Dec 2024 19:48:31 GMT
URLDownloader: Storing new ETag header: "1e8958921cf4d564a78efb09cd4307b1-74"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.RStudio/downloads/RStudio.dmg
{'Output': {'download_changed': True,
            'etag': '"1e8958921cf4d564a78efb09cd4307b1-74"',
            'last_modified': 'Mon, 16 Dec 2024 19:48:31 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.RStudio/downloads/RStudio.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.RStudio/downloads/RStudio.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.RStudio/downloads/RStudio.dmg/RStudio.app',
           'requirement': 'identifier "org.rstudio.RStudio" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'FYF2F5GFX4'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.RStudio/downloads/RStudio.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.61NmGG/RStudio.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.61NmGG/RStudio.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.61NmGG/RStudio.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.RStudio/downloads/RStudio.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Mathematics',
                       'description': 'RStudio is the premier integrated '
                                      'development environment for R. It is '
                                      'available in open source and commercial '
                                      'editions and runs on the desktop '
                                      '(Windows, Mac, and Linux) or over the '
                                      'web with RStudio Server.',
                       'developer': 'RStudio',
                       'display_name': 'RStudio',
                       'name': 'RStudio',
                       'requires': ['R'],
                       'unattended_install': True},
           'repo_subdirectory': 'apps/rstudio'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/rstudio/RStudio-2024.12.0+467.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/rstudio/RStudio-2024.12.0+467.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'RStudio',
                                                       'pkg_repo_path': 'apps/rstudio/RStudio-2024.12.0+467.dmg',
                                                       'pkginfo_path': 'apps/rstudio/RStudio-2024.12.0+467.plist',
                                                       'version': '2024.12.0+467'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 31, 4, 7, 40),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Mathematics',
                           'description': 'RStudio is the premier integrated '
                                          'development environment for R. It '
                                          'is available in open source and '
                                          'commercial editions and runs on the '
                                          'desktop (Windows, Mac, and Linux) '
                                          'or over the web with RStudio '
                                          'Server.',
                           'developer': 'RStudio',
                           'display_name': 'RStudio',
                           'installer_item_hash': '46958fb441ea8990a44e02cb5f89a331d8634a955a441a7e46fcf6714081e3c2',
                           'installer_item_location': 'apps/rstudio/RStudio-2024.12.0+467.dmg',
                           'installer_item_size': 603231,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.rstudio.desktop',
                                         'CFBundleName': 'RStudio',
                                         'CFBundleShortVersionString': '2024.12.0+467',
                                         'CFBundleVersion': '2024.12.0+467',
                                         'minosversion': '10.15',
                                         'path': '/Applications/RStudio.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'RStudio.app'}],
                           'minimum_os_version': '10.15',
                           'name': 'RStudio',
                           'requires': ['R'],
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '2024.12.0+467'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/rstudio/RStudio-2024.12.0+467.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/rstudio/RStudio-2024.12.0+467.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.RStudio/receipts/RStudio.munki-receipt-20241230-200740.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.RStudio/downloads/RStudio.dmg

The following new items were imported into Munki:
    Name     Version        Catalogs  Pkginfo Path                              Pkg Repo Path                           Icon Repo Path
    ----     -------        --------  ------------                              -------------                           --------------
    RStudio  2024.12.0+467  testing   apps/rstudio/RStudio-2024.12.0+467.plist  apps/rstudio/RStudio-2024.12.0+467.dmg
```
