### PR TITLE
Update Viber.download.recipe

### DIFF
--- a/Viber/Viber.download.recipe
+++ b/Viber/Viber.download.recipe
@@ -21,7 +21,7 @@
         	<key>Arguments</key>
         	<dict>
         		<key>url</key>
-        		<string>https://download.viber.com/desktop/mac/Viber.dmg</string>
+        		<string>https://download.viber.com/desktop/mac/online/Viber.dmg</string>
         		<key>filename</key>
         		<string>%NAME%.dmg</string>
         	</dict>
@@ -29,6 +29,17 @@
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/Viber.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.viber.osx" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "86ZW9CB9ZQ")</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Hi, @joshua-d-miller 

The current Viber download recipe is picking up an app with `..` as the version number 
```
<key>CFBundleShortVersionString</key>
<string>..</string>
```

This PR
- Updates the download URL
- Adds CodeSignatureVerifier

Output from a successful -v run
```
autopkg run -v Viber.munki.recipe
Looking for com.github.joshua-d-miller.download.viber...
Did not find com.github.joshua-d-miller.download.viber in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.joshua-d-miller.download.viber...
Found com.github.joshua-d-miller.download.viber in recipe map
**load_recipe time: 0.01583187500364147
Processing Viber.munki.recipe...
WARNING: Viber.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 27 Feb 2025 15:31:51 GMT
URLDownloader: Storing new ETag header: "c98268002d4c74365fe4e714e4652463"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.viber/downloads/Viber.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.viber/downloads/Viber.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.PCvLoO/Viber.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.PCvLoO/Viber.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.PCvLoO/Viber.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/viber/Viber-1.0.0.71.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/viber/Viber-1.0.0.71.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.viber/receipts/Viber.munki-receipt-20250314-163719.plist

The following new items were downloaded:
    Download Path                                                                                                
    -------------                                                                                                
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.joshua-d-miller.autopkg.munki.viber/downloads/Viber.dmg  

The following new items were imported into Munki:
    Name   Version   Catalogs  Pkginfo Path                     Pkg Repo Path                  Icon Repo Path  
    ----   -------   --------  ------------                     -------------                  --------------  
    Viber  1.0.0.71  testing   apps/viber/Viber-1.0.0.71.plist  apps/viber/Viber-1.0.0.71.dmg
```